### PR TITLE
Implement test coverage reporting via karma-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 node_modules
 npm-debug.log
+test/coverage

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,14 @@ module.exports = function(config) {
     ]),
     browsers: ['PhantomJS'],
     autoWatch: false,
-    singleRun: true
+    singleRun: true,
+    reporters: ['progress','coverage'],
+    preprocessors: {
+      'angular-pouchdb.js': ['coverage']
+    },
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'test/coverage'
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.24",
     "karma-cli": "0.0.4",
+    "karma-coverage": "^0.2.7",
     "karma-jasmine": "^0.3.3",
     "karma-phantomjs-launcher": "^0.1.4",
     "ng-annotate": "^0.14.1",


### PR DESCRIPTION
Relates to #27 

I'll leave up to you to decide on how to push the `.lcov` to Coveralls (or any other service), even because I'm not owner of this repository :)