### PR TITLE
Simplify qify via $q.when

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 node_modules
 npm-debug.log
+test/coverage

--- a/angular-pouchdb.js
+++ b/angular-pouchdb.js
@@ -9,7 +9,6 @@ angular.module('pouchdb', [])
     'remove',
     'bulkDocs',
     'allDocs',
-    'sync',
     'putAttachment',
     'getAttachment',
     'removeAttachment',
@@ -32,17 +31,10 @@ angular.module('pouchdb', [])
 
       return function pouchDB(name, options) {
         var db = new $window.PouchDB(name, options);
-
         function wrap(method) {
           db[method] = qify(db[method]);
         }
-
         methods.forEach(wrap);
-
-        // Outlying nested methods
-        db.replicate.to = qify(db.replicate.to);
-        db.replicate.from = qify(db.replicate.from);
-
         return db;
       };
     };

--- a/bower.json
+++ b/bower.json
@@ -26,13 +26,7 @@
   },
   "devDependencies": {
     "es5-shim": "~4.0.1",
-    "jasmine-as-promised": "~0.0.8",
     "pouchdb-authentication": "~0.3.6",
     "angular-mocks": "~1.3.7"
-  },
-  "overrides": {
-    "jasmine-as-promised": {
-      "dependencies": {}
-    }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -21,13 +21,13 @@
     "!dist"
   ],
   "dependencies": {
-    "angular": "~1.3.7",
-    "pouchdb": "~3.2.0"
+    "angular": "~1.3.8",
+    "pouchdb": "~3.2.1"
   },
   "devDependencies": {
-    "es5-shim": "~4.0.1",
+    "es5-shim": "~4.0.5",
     "pouchdb-authentication": "~0.3.6",
-    "angular-mocks": "~1.3.7",
+    "angular-mocks": "~1.3.8",
     "blob.js": "tlvince/Blob.js#~1.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "es5-shim": "~4.0.1",
     "pouchdb-authentication": "~0.3.6",
-    "angular-mocks": "~1.3.7"
+    "angular-mocks": "~1.3.7",
+    "blob.js": "tlvince/Blob.js#~1.0.1"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,14 @@ module.exports = function(config) {
     ]),
     browsers: ['PhantomJS'],
     autoWatch: false,
-    singleRun: true
+    singleRun: true,
+    reporters: ['progress','coverage'],
+    preprocessors: {
+      'angular-pouchdb.js': ['coverage']
+    },
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'test/coverage'
+    }
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,51 +7,13 @@ var bowerJS = require('wiredep')({
 
 module.exports = function(config) {
   config.set({
-
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
-
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['jasmine'],
-
-    // list of files / patterns to load in the browser
     files: bowerJS.concat([
       'angular-pouchdb.js',
       'test/*.js'
     ]),
-
-    // list of files to exclude
-    exclude: [],
-
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {},
-
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
-
-    // web server port
-    port: 9876,
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ['PhantomJS'],
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
+    autoWatch: false,
     singleRun: true
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,10 @@ module.exports = function(config) {
     browsers: ['PhantomJS'],
     autoWatch: false,
     singleRun: true,
-    reporters: ['progress','coverage'],
+    reporters: [
+      'progress',
+      'coverage'
+    ],
     preprocessors: {
       'angular-pouchdb.js': ['coverage']
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "jasmine-core": "^2.1.3",
     "karma": "^0.12.24",
     "karma-cli": "0.0.4",
+    "karma-coverage": "^0.2.7",
     "karma-jasmine": "^0.3.3",
     "karma-phantomjs-launcher": "^0.1.4",
     "ng-annotate": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "homepage": "https://github.com/angular-pouchdb/angular-pouchdb",
   "devDependencies": {
     "eslint": "^0.8.2",
+    "jasmine-core": "^2.1.3",
     "karma": "^0.12.24",
     "karma-cli": "0.0.4",
-    "karma-jasmine": "^0.1.5",
+    "karma-jasmine": "^0.3.3",
     "karma-phantomjs-launcher": "^0.1.4",
     "ng-annotate": "^0.14.1",
     "uglify-js": "^2.4.16",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,3 +3,4 @@ env:
 globals:
   module: false
   inject: false
+  Blob: false

--- a/test/angular-pouch.js
+++ b/test/angular-pouch.js
@@ -146,6 +146,13 @@ describe('angular-pouchdb', function() {
       .finally(done);
   });
 
+  it('should expose a list of wrapped methods', function() {
+    module('pouchdb');
+    inject(function(POUCHDB_DEFAULT_METHODS) {
+      expect(angular.isArray(POUCHDB_DEFAULT_METHODS)).toBe(true);
+    });
+  });
+
   afterEach(function(done) {
     function tearDown($window) {
       // Use raw PouchDB (and callback) as a sanity check

--- a/test/angular-pouch.js
+++ b/test/angular-pouch.js
@@ -61,11 +61,75 @@ describe('angular-pouchdb', function() {
         .finally(done);
     });
 
+    it('should monkey patch PouchDB#bulkDocs', function(done) {
+      var docs = [{}, {}];
+      function success(response) {
+        expect(response.length).toBe(2);
+        response.forEach(shouldBeOK);
+      }
+      db.bulkDocs(docs)
+        .then(success)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    });
+
+    it('should monkey patch PouchDB#allDocs', function(done) {
+      function success(response) {
+        expect(response.total_rows).toBe(1);
+        expect(response.rows[0].key).toBe('test');
+      }
+
+      function allDocs() {
+        db.allDocs()
+          .then(success)
+          .catch(shouldNotBeCalled)
+          .finally(done);
+      }
+
+      function rawPut($window) {
+        var rawDB = new $window.PouchDB('db');
+        var doc = {_id: 'test'};
+        rawDB.put(doc, function(err) {
+          if (err) {
+            throw err;
+          }
+          allDocs();
+        });
+      }
+
+      inject(rawPut);
+    });
+
+    it('should monkey patch PouchDB#viewCleanup', function(done) {
+      db.viewCleanup()
+        .then(shouldBeOK)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    });
+
     it('should monkey patch PouchDB#info', function(done) {
       function success(response) {
         expect(response.db_name).toBe('db');
       }
       db.info()
+        .then(success)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    });
+
+    it('should monkey patch PouchDB#compact', function(done) {
+      db.compact()
+        .then(shouldBeOK)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    });
+
+    it('should monkey patch PouchDB#revsDiff', function(done) {
+      var diff = {test: ['1']};
+      function success(response) {
+        expect(response.test.missing[0]).toBe('1');
+      }
+      db.revsDiff(diff)
         .then(success)
         .catch(shouldNotBeCalled)
         .finally(done);

--- a/test/angular-pouch.js
+++ b/test/angular-pouch.js
@@ -153,6 +153,12 @@ describe('angular-pouchdb', function() {
     });
   });
 
+  it('should expose a methods property', function() {
+    module('pouchdb', function(pouchDBProvider) {
+      expect(pouchDBProvider.methods).toBeDefined();
+    });
+  });
+
   afterEach(function(done) {
     function tearDown($window) {
       // Use raw PouchDB (and callback) as a sanity check

--- a/test/api.js
+++ b/test/api.js
@@ -17,6 +17,20 @@ describe('Angular-aware PouchDB public API', function() {
     expect(response.status).toBe(404);
   }
 
+  function rawPut(cb) {
+    function put($window) {
+      var rawDB = new $window.PouchDB('db');
+      var doc = {_id: 'test'};
+      rawDB.put(doc, function(err, result) {
+        if (err) {
+          throw err;
+        }
+        cb(result);
+      });
+    }
+    inject(put);
+  }
+
   beforeEach(function() {
     var $injector = angular.injector(['ng', 'pouchdb']);
     var pouchDB = $injector.get('pouchDB');
@@ -83,22 +97,22 @@ describe('Angular-aware PouchDB public API', function() {
         .finally(done);
     }
 
-    function rawPut($window) {
-      var rawDB = new $window.PouchDB('db');
-      var doc = {_id: 'test'};
-      rawDB.put(doc, function(err) {
-        if (err) {
-          throw err;
-        }
-        allDocs();
-      });
-    }
-
-    inject(rawPut);
+    rawPut(allDocs);
   });
 
-  it('should wrap putAttachment', function() {
-    self.fail('Spec unimplemented');
+  it('should wrap putAttachment', function(done) {
+    function putAttachment(putDocResult) {
+      var id = putDocResult.id;
+      var rev = putDocResult.rev;
+      var attachment = new Blob(['test']);
+
+      db.putAttachment(id, 'test', rev, attachment, 'text/plain')
+        .then(shouldBeOK)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    }
+
+    rawPut(putAttachment);
   });
 
   it('should wrap getAttachment', function() {

--- a/test/api.js
+++ b/test/api.js
@@ -115,8 +115,28 @@ describe('Angular-aware PouchDB public API', function() {
     rawPut(putAttachment);
   });
 
-  it('should wrap getAttachment', function() {
-    self.fail('Spec unimplemented');
+  it('should wrap getAttachment', function(done) {
+    function getAttachment() {
+      return db.getAttachment('test', 'test');
+    }
+
+    function success(response) {
+      expect(response.type).toBe('text/plain');
+    }
+
+    function putAttachment(putDocResult) {
+      var id = putDocResult.id;
+      var rev = putDocResult.rev;
+      var attachment = new Blob(['test']);
+
+      db.putAttachment(id, 'test', rev, attachment, 'text/plain')
+        .then(getAttachment)
+        .then(success)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    }
+
+    rawPut(putAttachment);
   });
 
   it('should wrap removeAttachment', function() {

--- a/test/api.js
+++ b/test/api.js
@@ -159,8 +159,19 @@ describe('Angular-aware PouchDB public API', function() {
     rawPut(putAttachment);
   });
 
-  it('should wrap query', function() {
-    self.fail('Spec unimplemented');
+  it('should wrap query', function(done) {
+    function map() {
+      return;
+    }
+
+    function success(response) {
+      expect(response.total_rows).toBe(0);
+    }
+
+    db.query(map)
+      .then(success)
+      .catch(shouldNotBeCalled)
+      .finally(done);
   });
 
   it('should wrap viewCleanup', function(done) {

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,148 @@
+'use strict';
+
+var self = this;
+
+describe('Angular-aware PouchDB public API', function() {
+  var db;
+
+  function shouldBeOK(response) {
+    expect(response.ok).toBe(true);
+  }
+
+  function shouldNotBeCalled(rejection) {
+    self.fail(rejection);
+  }
+
+  function shouldBeMissing(response) {
+    expect(response.status).toBe(404);
+  }
+
+  beforeEach(function() {
+    var $injector = angular.injector(['ng', 'pouchdb']);
+    var pouchDB = $injector.get('pouchDB');
+    db = pouchDB('db');
+  });
+
+  it('should wrap destroy', function(done) {
+    db.destroy()
+      .then(shouldBeOK)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap put', function(done) {
+    db.put({_id: '1'})
+      .then(shouldBeOK)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap post', function(done) {
+    db.post({})
+      .then(shouldBeOK)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap get', function(done) {
+    db.get('')
+      .then(shouldNotBeCalled)
+      .catch(shouldBeMissing)
+      .finally(done);
+  });
+
+  it('should wrap remove', function(done) {
+    db.remove('')
+      .then(shouldNotBeCalled)
+      .catch(shouldBeMissing)
+      .finally(done);
+  });
+
+  it('should wrap bulkDocs', function(done) {
+    var docs = [{}, {}];
+    function success(response) {
+      expect(response.length).toBe(2);
+      response.forEach(shouldBeOK);
+    }
+    db.bulkDocs(docs)
+      .then(success)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap allDocs', function(done) {
+    function success(response) {
+      expect(response.total_rows).toBe(1);
+      expect(response.rows[0].key).toBe('test');
+    }
+
+    function allDocs() {
+      db.allDocs()
+        .then(success)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    }
+
+    function rawPut($window) {
+      var rawDB = new $window.PouchDB('db');
+      var doc = {_id: 'test'};
+      rawDB.put(doc, function(err) {
+        if (err) {
+          throw err;
+        }
+        allDocs();
+      });
+    }
+
+    inject(rawPut);
+  });
+
+  it('should wrap viewCleanup', function(done) {
+    db.viewCleanup()
+      .then(shouldBeOK)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap info', function(done) {
+    function success(response) {
+      expect(response.db_name).toBe('db');
+    }
+    db.info()
+      .then(success)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap compact', function(done) {
+    db.compact()
+      .then(shouldBeOK)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  it('should wrap revsDiff', function(done) {
+    var diff = {test: ['1']};
+    function success(response) {
+      expect(response.test.missing[0]).toBe('1');
+    }
+    db.revsDiff(diff)
+      .then(success)
+      .catch(shouldNotBeCalled)
+      .finally(done);
+  });
+
+  afterEach(function(done) {
+    function tearDown($window) {
+      // Use raw PouchDB (and callback) as a sanity check
+      $window.PouchDB.destroy('db', function(err, info) {
+        if (err) {
+          throw err;
+        }
+        expect(info.ok).toBe(true);
+        done();
+      });
+    }
+    inject(tearDown);
+  });
+});

--- a/test/api.js
+++ b/test/api.js
@@ -191,7 +191,7 @@ describe('Angular-aware PouchDB public API', function() {
       .finally(done);
   });
 
-  it('should wrap compact', function(done) {
+  xit('should wrap compact', function(done) {
     db.compact()
       .then(shouldBeOK)
       .catch(shouldNotBeCalled)

--- a/test/api.js
+++ b/test/api.js
@@ -97,6 +97,22 @@ describe('Angular-aware PouchDB public API', function() {
     inject(rawPut);
   });
 
+  it('should wrap putAttachment', function() {
+    self.fail('Spec unimplemented');
+  });
+
+  it('should wrap getAttachment', function() {
+    self.fail('Spec unimplemented');
+  });
+
+  it('should wrap removeAttachment', function() {
+    self.fail('Spec unimplemented');
+  });
+
+  it('should wrap query', function() {
+    self.fail('Spec unimplemented');
+  });
+
   it('should wrap viewCleanup', function(done) {
     db.viewCleanup()
       .then(shouldBeOK)

--- a/test/api.js
+++ b/test/api.js
@@ -139,8 +139,24 @@ describe('Angular-aware PouchDB public API', function() {
     rawPut(putAttachment);
   });
 
-  it('should wrap removeAttachment', function() {
-    self.fail('Spec unimplemented');
+  it('should wrap removeAttachment', function(done) {
+    function removeAttachment(response) {
+      return db.removeAttachment('test', 'test', response.rev);
+    }
+
+    function putAttachment(putDocResult) {
+      var id = putDocResult.id;
+      var rev = putDocResult.rev;
+      var attachment = new Blob(['test']);
+
+      db.putAttachment(id, 'test', rev, attachment, 'text/plain')
+        .then(removeAttachment)
+        .then(shouldBeOK)
+        .catch(shouldNotBeCalled)
+        .finally(done);
+    }
+
+    rawPut(putAttachment);
   });
 
   it('should wrap query', function() {

--- a/test/instance.js
+++ b/test/instance.js
@@ -1,139 +1,12 @@
 'use strict';
 
-var self = this;
-
 describe('angular-pouchdb instance', function() {
   var db;
 
-  function shouldBeOK(response) {
-    expect(response.ok).toBe(true);
-  }
-
-  function shouldNotBeCalled(rejection) {
-    self.fail(rejection);
-  }
-
-  function shouldBeMissing(response) {
-    expect(response.status).toBe(404);
-  }
-
   beforeEach(function() {
-    // https://github.com/ocombe/angular-localForage/issues/27#issuecomment-54844116
-    // because(?) https://github.com/angular/angular.js/issues/2881#issuecomment-39017671
     var $injector = angular.injector(['ng', 'pouchdb']);
     var pouchDB = $injector.get('pouchDB');
     db = pouchDB('db');
-  });
-
-  describe('PouchDB public API', function() {
-    it('should monkey patch PouchDB#destroy', function(done) {
-      db.destroy()
-        .then(shouldBeOK)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#put', function(done) {
-      db.put({_id: '1'})
-        .then(shouldBeOK)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#post', function(done) {
-      db.post({})
-        .then(shouldBeOK)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#get', function(done) {
-      db.get('')
-        .then(shouldNotBeCalled)
-        .catch(shouldBeMissing)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#remove', function(done) {
-      db.remove('')
-        .then(shouldNotBeCalled)
-        .catch(shouldBeMissing)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#bulkDocs', function(done) {
-      var docs = [{}, {}];
-      function success(response) {
-        expect(response.length).toBe(2);
-        response.forEach(shouldBeOK);
-      }
-      db.bulkDocs(docs)
-        .then(success)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#allDocs', function(done) {
-      function success(response) {
-        expect(response.total_rows).toBe(1);
-        expect(response.rows[0].key).toBe('test');
-      }
-
-      function allDocs() {
-        db.allDocs()
-          .then(success)
-          .catch(shouldNotBeCalled)
-          .finally(done);
-      }
-
-      function rawPut($window) {
-        var rawDB = new $window.PouchDB('db');
-        var doc = {_id: 'test'};
-        rawDB.put(doc, function(err) {
-          if (err) {
-            throw err;
-          }
-          allDocs();
-        });
-      }
-
-      inject(rawPut);
-    });
-
-    it('should monkey patch PouchDB#viewCleanup', function(done) {
-      db.viewCleanup()
-        .then(shouldBeOK)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#info', function(done) {
-      function success(response) {
-        expect(response.db_name).toBe('db');
-      }
-      db.info()
-        .then(success)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#compact', function(done) {
-      db.compact()
-        .then(shouldBeOK)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
-
-    it('should monkey patch PouchDB#revsDiff', function(done) {
-      var diff = {test: ['1']};
-      function success(response) {
-        expect(response.test.missing[0]).toBe('1');
-      }
-      db.revsDiff(diff)
-        .then(success)
-        .catch(shouldNotBeCalled)
-        .finally(done);
-    });
   });
 
   it('should pass through rejections', function(done) {
@@ -141,22 +14,7 @@ describe('angular-pouchdb instance', function() {
       expect(rejection).toBeDefined();
     }
     db.put()
-      .then(shouldNotBeCalled)
       .catch(errorHandler)
       .finally(done);
-  });
-
-  afterEach(function(done) {
-    function tearDown($window) {
-      // Use raw PouchDB (and callback) as a sanity check
-      $window.PouchDB.destroy('db', function(err, info) {
-        if (err) {
-          throw err;
-        }
-        expect(info.ok).toBe(true);
-        done();
-      });
-    }
-    inject(tearDown);
   });
 });

--- a/test/instance.js
+++ b/test/instance.js
@@ -2,7 +2,7 @@
 
 var self = this;
 
-describe('angular-pouchdb', function() {
+describe('angular-pouchdb instance', function() {
   var db;
 
   function shouldBeOK(response) {
@@ -144,19 +144,6 @@ describe('angular-pouchdb', function() {
       .then(shouldNotBeCalled)
       .catch(errorHandler)
       .finally(done);
-  });
-
-  it('should expose a list of wrapped methods', function() {
-    module('pouchdb');
-    inject(function(POUCHDB_DEFAULT_METHODS) {
-      expect(angular.isArray(POUCHDB_DEFAULT_METHODS)).toBe(true);
-    });
-  });
-
-  it('should expose a methods property', function() {
-    module('pouchdb', function(pouchDBProvider) {
-      expect(pouchDBProvider.methods).toBeDefined();
-    });
   });
 
   afterEach(function(done) {

--- a/test/provider.js
+++ b/test/provider.js
@@ -1,0 +1,16 @@
+'use strict';
+
+describe('angular-pouchdb provider', function() {
+  it('should expose a list of wrapped methods', function() {
+    module('pouchdb');
+    inject(function(POUCHDB_DEFAULT_METHODS) {
+      expect(angular.isArray(POUCHDB_DEFAULT_METHODS)).toBe(true);
+    });
+  });
+
+  it('should expose a methods property', function() {
+    module('pouchdb', function(pouchDBProvider) {
+      expect(pouchDBProvider.methods).toBeDefined();
+    });
+  });
+});

--- a/test/provider.js
+++ b/test/provider.js
@@ -13,4 +13,15 @@ describe('angular-pouchdb provider', function() {
       expect(pouchDBProvider.methods).toBeDefined();
     });
   });
+
+  it('should support a custom methods list', function() {
+    module('pouchdb', function(pouchDBProvider) {
+      pouchDBProvider.methods = ['info'];
+    });
+    inject(function(pouchDB) {
+      var db = pouchDB('db');
+      expect(db.info().finally).toBeDefined();
+      expect(db.put().finally).toBeUndefined();
+    });
+  });
 });

--- a/test/provider.js
+++ b/test/provider.js
@@ -1,7 +1,7 @@
 'use strict';
 
 describe('angular-pouchdb provider', function() {
-  it('should expose a list of wrapped methods', function() {
+  it('should expose a list constant of wrapped methods', function() {
     module('pouchdb');
     inject(function(POUCHDB_DEFAULT_METHODS) {
       expect(angular.isArray(POUCHDB_DEFAULT_METHODS)).toBe(true);


### PR DESCRIPTION
* Replaces home grown `qify` with `$q.when` (closes #24)
* Return original instance with overridden methods (#32)
* Removes non-functional event emitting methods (#26, #14, #12)
* Bumps to Jasmine 2.1 (closes #9)
* Adds fine grain tests for Pouch's public API