### PR TITLE
Fixed wrap methods after methods with parent

### DIFF
--- a/angular-pouchdb.js
+++ b/angular-pouchdb.js
@@ -65,7 +65,8 @@ angular.module('pouchdb', [])
           var wrapFunction = methods[method];
 
           if (!angular.isString(wrapFunction)) {
-            return wrapMethods(db, wrapFunction, method);
+            wrapMethods(db, wrapFunction, method);
+            continue;
           }
 
           wrapFunction = pouchDBDecorators[wrapFunction];

--- a/test/provider.js
+++ b/test/provider.js
@@ -17,13 +17,21 @@ describe('angular-pouchdb provider', function() {
   it('should support a custom methods list', function() {
     module('pouchdb', function(pouchDBProvider) {
       pouchDBProvider.methods = {
-        info: 'qify'
+        info: 'qify',
+        replicate: {
+          to: 'eventEmitter',
+          from: 'eventEmitter'
+        },
+        search: 'qify',
+        '\uffff': 'qify'
       };
     });
     inject(function(pouchDB) {
       var db = pouchDB('db');
       expect(db.info().finally).toBeDefined();
       expect(db.put().finally).toBeUndefined();
+      expect(db.search).toBeDefined();
+      expect(db['\uffff']).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
Without this [pouchdb-quick-search](https://github.com/nolanlawson/pouchdb-quick-search) does not work