### PR TITLE
Removes the 'engines' requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
     "url": "https://github.com/angular-pouchdb/angular-pouchdb/issues"
   },
   "homepage": "https://angular-pouchdb.github.io/angular-pouchdb/",
-  "engines": {
-    "node": ">=4 <5"
-  },
   "dependencies": {
     "angular": ">=1 <2",
     "pouchdb-browser": "^6.0.7"


### PR DESCRIPTION
A mismatched engine causes an error when using yarn.
